### PR TITLE
Added tests for datapackage.json parsing; now extracts ODRS metadata.

### DIFF
--- a/lib/data_kitten/publishing_formats/datapackage.rb
+++ b/lib/data_kitten/publishing_formats/datapackage.rb
@@ -12,7 +12,7 @@ module DataKitten
 
       def self.supported?(instance)
         instance.send(:load_file, "datapackage.json")
-      rescue 
+      rescue => e
         false
       end
 
@@ -52,6 +52,14 @@ module DataKitten
         end
       end
 
+      def rights
+         if metadata["rights"]
+            [ Rights.new( ( metadata["rights"] || []).each_with_object({}){|(k,v), h| h[k.to_sym] = v} ) ]
+         else
+            []
+         end 
+      end
+      
       # A list of contributors.
       #
       # @see Dataset#contributors

--- a/spec/publishing_format/datapackage.json
+++ b/spec/publishing_format/datapackage.json
@@ -1,0 +1,14 @@
+{
+    "name": "identifier",
+    "title": "Test Dataset",
+    "description": "This is a test dataset",
+    "licenses": [{
+        "id": "odc-pddl",
+        "url": "http://opendatacommons.org/licenses/pddl/"
+    }],
+    "sources": [{
+        "name": "Somewhere Else",
+        "web": "http://data.example.org/123"
+    }],
+    "keywords": ["data", "finances", "spending"]
+}

--- a/spec/publishing_format/datapackage_spec.rb
+++ b/spec/publishing_format/datapackage_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+#This is required to specify a load_file function which currently
+#is only available on git origin
+#
+#Supply a prefix to separate out test filesTes
+class DataPackageTestDataset < DataKitten::Dataset
+    
+    def initialize( options )
+        @prefix = options[:prefix]
+        super        
+    end
+    
+    def load_file(file)
+        File.read( File.join( File.dirname(File.realpath(__FILE__)) , "#{@prefix}#{file}" ) )
+    end
+    
+end
+
+describe DataKitten::PublishingFormats::Datapackage do
+    
+    context "when detecting format" do
+        
+        it "should detect datapackage.json" do
+            d = DataPackageTestDataset.new(:access_url => "http://example.org")                    
+            expect( d.publishing_format ).to eql(:datapackage)                 
+        end
+
+        it "should not be a data package if there is no datapackage.json" do
+            d = DataPackageTestDataset.new(:access_url => "http://example.org", 
+                :prefix => "missing")        
+            expect( d.publishing_format ).to eql(nil)                 
+        end        
+                
+    end
+    
+    context "when reading a basic datapackage.json file" do
+        
+        before(:each) do 
+            @dataset = DataPackageTestDataset.new(:access_url => "http://example.org")
+        end
+        
+        it "should parse basic metadata" do
+            expect( @dataset.data_title ).to eql("Test Dataset")
+            expect( @dataset.description ).to eql("This is a test dataset")
+        end
+        
+        it "should extract sources" do
+            expect( @dataset.sources.length ).to eql(1)
+            source = @dataset.sources.first
+            expect( source.name ).to eql("Somewhere Else")
+            expect( source.web ).to eql("http://data.example.org/123")
+        end
+        
+        it "should extract licenses" do
+            expect( @dataset.licenses.length ).to eql(1)
+            license = @dataset.licenses.first
+            expect( license.id ).to eql("odc-pddl")
+            expect( license.uri ).to eql("http://opendatacommons.org/licenses/pddl/")
+            expect( @dataset.rights).to eql([])            
+        end
+        
+        it "should extract keywords" do
+            expect( @dataset.keywords.length ).to eql(3)
+            expect( @dataset.keywords ).to eql( ["data", "finances", "spending"] )
+        end
+        
+    end
+    
+    context "when reading rights information" do
+        
+        before(:each) do 
+            @dataset = DataPackageTestDataset.new(
+                :access_url => "http://example.org", :prefix=>"odrs-")
+            @rights = @dataset.rights().first
+        end        
+        
+        it "should extract licenses" do
+            expect( @rights.contentLicense ).to eql("http://reference.data.gov.uk/id/open-government-licence")
+            expect( @rights.dataLicense ).to eql("http://reference.data.gov.uk/id/open-government-licence")
+        end
+
+        it "should extract attribution details" do
+            expect( @rights.attributionURL).to eql("http://gov.example.org/dataset/example")
+            expect( @rights.attributionText).to eql("Example Department")
+        end
+    end
+    
+    
+end

--- a/spec/publishing_format/linked_data_spec.rb
+++ b/spec/publishing_format/linked_data_spec.rb
@@ -51,11 +51,11 @@ describe DataKitten::PublishingFormats::LinkedData do
 
         it "should fallback to using suffix of URI" do
             body=<<-EOL 
-              <http://example.org/doc/dataset> a <http://www.w3.org/ns/dcat#Dataset>.
+              <http://example.org/doc/dataset> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/dcat#Dataset>.
             EOL
     
             FakeWeb.register_uri(:get, "http://example.org/doc/dataset.ttl", :body=>body, :content_type=>"text/plain") 
-            d = DataKitten::Dataset.new( access_url: "http://example.org/doc/dataset")        
+            d = DataKitten::Dataset.new( access_url: "http://example.org/doc/dataset.ttl")        
             expect( d.publishing_format ).to eql(:rdf)                 
         end        
                 

--- a/spec/publishing_format/odrs-datapackage.json
+++ b/spec/publishing_format/odrs-datapackage.json
@@ -1,0 +1,11 @@
+{
+    "name": "identifier",
+    "title": "ODRS Example",
+    "rights": {
+        "contentLicense": "http://reference.data.gov.uk/id/open-government-licence",
+        "dataLicense": "http://reference.data.gov.uk/id/open-government-licence",
+        "copyrightNotice": "© Crown copyright 2013",
+        "attributionText": "Example Department",
+        "attributionURL": "http://gov.example.org/dataset/example"
+    }        
+}


### PR DESCRIPTION
This closes #27. Can now extract ODRS metadata from datapackage.json
