### PR TITLE
Always return either a Right object or nil

### DIFF
--- a/lib/data_kitten/publishing_formats/datapackage.rb
+++ b/lib/data_kitten/publishing_formats/datapackage.rb
@@ -54,9 +54,9 @@ module DataKitten
 
       def rights
          if metadata["rights"]
-            [ Rights.new( ( metadata["rights"] || []).each_with_object({}){|(k,v), h| h[k.to_sym] = v} ) ]
+            Rights.new( ( metadata["rights"] || []).each_with_object({}){|(k,v), h| h[k.to_sym] = v} )
          else
-            []
+            nil
          end 
       end
       

--- a/lib/data_kitten/publishing_formats/rdfa.rb
+++ b/lib/data_kitten/publishing_formats/rdfa.rb
@@ -75,8 +75,8 @@ module DataKitten
                               )
         end
       rescue => e
-        puts e
-        puts e.backtrace
+        #puts e
+        #puts e.backtrace
         nil
       end
       

--- a/spec/publishing_format/datapackage_spec.rb
+++ b/spec/publishing_format/datapackage_spec.rb
@@ -57,7 +57,7 @@ describe DataKitten::PublishingFormats::Datapackage do
             license = @dataset.licenses.first
             expect( license.id ).to eql("odc-pddl")
             expect( license.uri ).to eql("http://opendatacommons.org/licenses/pddl/")
-            expect( @dataset.rights).to eql([])            
+            expect( @dataset.rights).to eql(nil)            
         end
         
         it "should extract keywords" do
@@ -72,7 +72,7 @@ describe DataKitten::PublishingFormats::Datapackage do
         before(:each) do 
             @dataset = DataPackageTestDataset.new(
                 :access_url => "http://example.org", :prefix=>"odrs-")
-            @rights = @dataset.rights().first
+            @rights = @dataset.rights()
         end        
         
         it "should extract licenses" do


### PR DESCRIPTION
Fixes inconsistency with response to the `rights` method. Will now always return a Rights object or nil.
