### PR TITLE
Added a LinkedData origin. Uses HEAD request to probe content type

### DIFF
--- a/lib/data_kitten/origins.rb
+++ b/lib/data_kitten/origins.rb
@@ -1,6 +1,7 @@
 require 'data_kitten/origins/git'
 require 'data_kitten/origins/web_service'
 require 'data_kitten/origins/html'
+require 'data_kitten/origins/linked_data'
 
 module DataKitten
   
@@ -12,7 +13,8 @@ module DataKitten
       [
         DataKitten::Origins::Git,
         DataKitten::Origins::HTML,
-        DataKitten::Origins::WebService
+        DataKitten::Origins::WebService,
+        DataKitten::Origins::LinkedData,
       ].each do |origin|
         if origin.supported?(@access_url)
           extend origin 

--- a/lib/data_kitten/origins/linked_data.rb
+++ b/lib/data_kitten/origins/linked_data.rb
@@ -1,0 +1,37 @@
+module DataKitten
+  
+  module Origins
+    
+    # Linked Data origin module. Automatically mixed into {Dataset} for datasets that are accessed through an API.
+    #
+    # @see Dataset
+    #
+    module LinkedData
+  
+      private
+  
+      def self.supported?(uri)
+        content_type = RestClient.head(uri).headers[:content_type]
+        return nil unless content_type
+        
+        return RDF::Format.content_types.keys.include?( 
+            content_type.split(";").first )    
+            
+      rescue
+          false
+      end
+
+      public
+
+      # The origin type of the dataset.
+      # @return [Symbol] +:linkeddata+
+      # @see Dataset#origin
+      def origin
+        :linkeddata
+      end
+
+    end
+
+  end
+
+end

--- a/spec/origins/linked_data_spec.rb
+++ b/spec/origins/linked_data_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe DataKitten::Origins::LinkedData do
+    
+    context "when detecting origin" do
+    
+        it "should ignore errors" do       
+            FakeWeb.register_uri(:head, "http://example.org/not-found", :status => ["404", "Not Found"])            
+            d = DataKitten::Dataset.new( access_url: "http://example.org/not-found")
+            expect( d.origin ).to eql(nil)              
+        end
+        
+        it "should support turtle" do
+            FakeWeb.register_uri(:head, "http://example.org/doc/dataset", :body=>"", :content_type=>"text/turtle") 
+            d = DataKitten::Dataset.new( access_url: "http://example.org/doc/dataset")   
+            expect( d.origin ).to eql(:linkeddata)                           
+        end        
+        
+    end
+    
+end

--- a/spec/publishing_format/rdfa_spec.rb
+++ b/spec/publishing_format/rdfa_spec.rb
@@ -18,7 +18,8 @@ describe DataKitten::PublishingFormats::RDFa do
         it "should detect DCAT Datasets" do
             dcat_rdfa = File.read( File.join( File.dirname(File.realpath(__FILE__)) , "basic-dcat-rdfa.html" ) )         
             FakeWeb.register_uri(:get, "http://example.org/rdfa", :body=>dcat_rdfa, :content_type=>"text/html")            
-            d = DataKitten::Dataset.new( access_url: "http://example.org/rdfa")        
+            d = DataKitten::Dataset.new( access_url: "http://example.org/rdfa")
+            expect( d.publishing_format ).to eql(:rdfa)        
             expect( d.supported? ).to eql(true)                    
         end
     end


### PR DESCRIPTION
Added an initial Linked Data origin, just does a HEAD request to test if content type delivered from the URL is one of the supported RDF serializations. This should fix #36.

There's still a bit of an inconsistency between this and the publishing format though, as the latter may also attempt to use autodiscovery. In that case the origin will be :html rather than :linkeddata, but the format will still be :linkeddata, which I think makes some sense.
