### PR TITLE
Fix publisher for DGU

### DIFF
--- a/lib/data_kitten/publishing_formats/ckan.rb
+++ b/lib/data_kitten/publishing_formats/ckan.rb
@@ -145,7 +145,11 @@ module DataKitten
       end
 
       def select_extras(group, key)
-        group['result']['extras'].select {|e| e["key"] == key }.first['value']
+        extra = group["extras"][key] rescue ""
+        if extra == ""
+          extra = group['result']['extras'].select {|e| e["key"] == key }.first['value'] rescue ""
+        end
+        extra
       end
 
       def fetch_publisher(id)
@@ -166,8 +170,8 @@ module DataKitten
         [
           Agent.new(
                     :name => @group["display_name"] || @group["result"]["name"],
-                    :homepage => @group["extras"]["website-url"] || select_extras(@group, "website-url"),
-                    :mbox => @group["extras"]["contact-email"] || select_extras(@group, "contact-email")
+                    :homepage => select_extras(@group, "website-url"),
+                    :mbox => select_extras(@group, "contact-email")
                     )
         ]
       end


### PR DESCRIPTION
data.gov.uk made a schema change to their CKAN install, and now use Organizations to refer to publishers, rather than groups. This reflects this change, but also supports groups. Bonus refactor too!
